### PR TITLE
Align release workflow with tag ref and remove invalid asset upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create ${{ steps.tag-name.outputs.tagname }} --generate-notes --fail-on-no-commits
+          gh release create "${{ steps.tag-name.outputs.tagname }}" --generate-notes --fail-on-no-commits

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,10 @@ jobs:
         # this section via https://mbund.dev/posts/advanced-github/#releases
         id: tag-name
         run: |
-          echo "tagname=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "tagname=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
 
       - name: Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create ${{ steps.tag-name.outputs.tagname }} --generate-notes --fail-on-no-commits
-          gh release upload ${{ steps.tag-name.outputs.tagname }} canvas-cli-x86_64-unknown-linux-musl


### PR DESCRIPTION
### Motivation
- Ensure the release job uses the pushed tag name as the release identifier instead of the short commit SHA.
- Remove an invalid `gh release upload` invocation that referenced a non-existent binary in this repository.

### Description
- Updated the `Get tag name` step to emit `tagname=${GITHUB_REF_NAME}` instead of using `git rev-parse --short HEAD` so the workflow uses the pushed tag.
- Removed the `gh release upload` line that attempted to upload `canvas-cli-x86_64-unknown-linux-musl` since that asset does not exist in this repo.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69892bd6917c8323b49faae626900c18)